### PR TITLE
Generate new lock-file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install poetry
+          poetry lock --no-update
           poetry install --with dev
 
       - name: Run pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
-default_language_version:
-  python: python3.10
+---
 repos:
   - repo: https://github.com/psf/black
     rev: 22.3.0


### PR DESCRIPTION
Tests would fail due to an old (but not invalid) lock file. This regenerates the lock-file without updating anything, hopefully solving this issue.  Annoyingly no way to test this without actually deploying and running the workflows…